### PR TITLE
feat(gen): use FormData with generation_provider=gemini; persist prov…

### DIFF
--- a/app/api/generation/status/route.ts
+++ b/app/api/generation/status/route.ts
@@ -119,8 +119,11 @@ export async function GET(request: NextRequest) {
         await kv.set(job.jobId, job);
         lastStepTime = Date.now();
         console.log(`XXX 244 - since start ${Date.now() - startTime}ms, since last step=${Date.now() - lastStepTime}ms`);
-        // 立即启动pipeline
+        // 立即启动pipeline（仅在选择 Kling 时）
+        const selectedProvider = (job as any)?.input?.provider || (process.env.IMAGE_PROVIDER || 'kling');
+        if (selectedProvider === 'kling') {
         runImageGenerationPipeline(job.jobId, 0);
+        }
         // console.log(`[API_STATUS | Job ${job.jobId.slice(-8)}] 🚀 Pipeline started in background for suggestion 0.`);
         lastStepTime = Date.now();
         console.log(`XXX 255 - since start ${Date.now() - startTime}ms, since last step=${Date.now() - lastStepTime}ms`);
@@ -151,8 +154,11 @@ export async function GET(request: NextRequest) {
       // 🔍 NEW: Pipeline trigger logging
       // console.log(`[API_STATUS | Job ${job.jobId.slice(-8)}] 🚀 About to start pipeline in background...`);
 
-      // Start the pipeline in the background.
+      // Start the pipeline in the background（仅在选择 Kling 时）。
+      const selectedProvider = (job as any)?.input?.provider || (process.env.IMAGE_PROVIDER || 'kling');
+      if (selectedProvider === 'kling') {
       runImageGenerationPipeline(job.jobId, suggestionIndex);
+      }
       lastStepTime = Date.now();
       console.log(`XXX 288 - since start ${Date.now() - startTime}ms, since last step=${Date.now() - lastStepTime}ms`);
 

--- a/lib/ai/providers/GeminiProvider.ts
+++ b/lib/ai/providers/GeminiProvider.ts
@@ -7,35 +7,70 @@ export class GeminiProvider implements ImageGenProvider {
   id: ProviderId = 'gemini';
 
   async generateFinalImages(ctx: GenerationContext, emit: EmitProgress): Promise<GenerateResult> {
+    console.log('🚀 [GEMINI_PROVIDER] ===== GEMINI PROVIDER STARTED =====');
+    console.log('🚀 [GEMINI_PROVIDER] 📋 Context details:');
+    console.log('🚀 [GEMINI_PROVIDER] 📋 - Job ID:', ctx.jobId);
+    console.log('🚀 [GEMINI_PROVIDER] 📋 - Suggestion index:', ctx.suggestionIndex);
+    console.log('🚀 [GEMINI_PROVIDER] 📋 - Human image URL:', ctx.humanImage.url?.substring(0, 100) + '...');
+    console.log('🚀 [GEMINI_PROVIDER] 📋 - Garment image URL:', ctx.garmentImage?.url?.substring(0, 100) + '...' || 'N/A');
+    console.log('🚀 [GEMINI_PROVIDER] 📋 - User ID:', ctx.userId);
+    
     emit({ step: 'init' });
 
     // Build prompt with priority similar to kling.ts
+    console.log('🚀 [GEMINI_PROVIDER] 🔧 Building prompt...');
     let finalPrompt = '';
     const suggestion = ctx.suggestion as any | undefined;
+    
+    console.log('🚀 [GEMINI_PROVIDER] 🔧 Suggestion data available:', !!suggestion);
+    console.log('🚀 [GEMINI_PROVIDER] 🔧 Style suggestion available:', !!suggestion?.styleSuggestion);
+    console.log('🚀 [GEMINI_PROVIDER] 🔧 Image prompt available:', !!suggestion?.styleSuggestion?.image_prompt);
+    
     if (suggestion?.styleSuggestion?.image_prompt) {
       finalPrompt = suggestion.styleSuggestion.image_prompt;
+      console.log('🚀 [GEMINI_PROVIDER] 🔧 Using AI-generated image_prompt (highest priority)');
     } else if (suggestion?.styleSuggestion?.outfit_suggestion) {
       const outfitDetails = suggestion.styleSuggestion.outfit_suggestion;
       const outfitDescription = outfitDetails.explanation || outfitDetails.style_summary || "A stylish outfit";
       finalPrompt = `${outfitDetails.outfit_title || "Stylish Look"}. ${outfitDescription}`;
+      console.log('🚀 [GEMINI_PROVIDER] 🔧 Using outfit details fallback');
     } else {
       finalPrompt = "A full-body shot of a person in a stylish outfit, realistic, well-lit, high-quality.";
+      console.log('🚀 [GEMINI_PROVIDER] 🔧 Using default fallback prompt');
     }
+    
     finalPrompt = `${finalPrompt}. ${IMAGE_FORMAT_DESCRIPTION} ${STRICT_REALISM_PROMPT_BLOCK}`;
     if (finalPrompt.length > 2500) {
+      console.log('🚀 [GEMINI_PROVIDER] ⚠️ Prompt too long, truncating from', finalPrompt.length, 'to 2500 chars');
       finalPrompt = finalPrompt.substring(0, 2500);
     }
+    
+    console.log('🚀 [GEMINI_PROVIDER] ===== FINAL PROMPT FOR GEMINI =====');
+    console.log('🚀 [GEMINI_PROVIDER] 📄 PROMPT LENGTH:', finalPrompt.length);
+    console.log('🚀 [GEMINI_PROVIDER] 📄 PROMPT CONTENT:', finalPrompt);
+    console.log('🚀 [GEMINI_PROVIDER] ===== END PROMPT =====');
 
     emit({ step: 'submit' });
+    console.log('🚀 [GEMINI_PROVIDER] 🔄 Calling Gemini service...');
+    
     const images = await generateFinalImagesWithGemini({
       prompt: finalPrompt,
       humanImageUrl: ctx.humanImage.url,
+      humanImageName: ctx.humanImage.name,
+      humanImageType: ctx.humanImage.type,
       garmentImageUrl: ctx.garmentImage?.url,
       garmentImageName: ctx.garmentImage?.name,
       garmentImageType: ctx.garmentImage?.type,
     });
+    
+    console.log('🚀 [GEMINI_PROVIDER] ✅ Gemini service returned', images.length, 'images');
+    images.forEach((img, i) => {
+      console.log('🚀 [GEMINI_PROVIDER] 📷 Image', i + 1, 'type:', img.substring(0, 30) + '...');
+    });
 
     emit({ step: 'save' });
+    console.log('🚀 [GEMINI_PROVIDER] 💾 Saving results to KV...');
+    
     // Persist minimal fields into KV (align with existing job shape)
     if (ctx.job) {
       const job = ctx.job;
@@ -44,10 +79,16 @@ export class GeminiProvider implements ImageGenProvider {
         job.suggestions[ctx.suggestionIndex].finalPrompt = finalPrompt;
         job.updatedAt = Date.now();
         await kv.set(job.jobId, job);
+        console.log('🚀 [GEMINI_PROVIDER] ✅ KV updated successfully');
+      } else {
+        console.log('🚀 [GEMINI_PROVIDER] ⚠️ No suggestion found at index', ctx.suggestionIndex);
       }
+    } else {
+      console.log('🚀 [GEMINI_PROVIDER] ⚠️ No job context provided');
     }
 
     emit({ step: 'done' });
+    console.log('🚀 [GEMINI_PROVIDER] ===== GEMINI PROVIDER COMPLETED =====');
     return { finalImageUrls: images, finalPrompt };
   }
 }

--- a/lib/ai/services/gemini.ts
+++ b/lib/ai/services/gemini.ts
@@ -1,65 +1,128 @@
 import { fetchWithTimeout, urlToFile, fileToBase64 } from "../utils";
 
-const GEMINI_API_URL = process.env.GEMINI_API_URL || "";
 const GEMINI_API_KEY = process.env.GEMINI_API_KEY || "";
+const GEMINI_IMAGE_MODEL = process.env.GEMINI_IMAGE_MODEL || 'gemini-2.5-flash-image-preview';
 
 export interface GeminiGenerateParams {
   prompt: string;
   humanImageUrl: string;
+  humanImageName: string;
+  humanImageType: string;
   garmentImageUrl?: string;
   garmentImageName?: string;
   garmentImageType?: string;
 }
 
 export async function generateFinalImagesWithGemini(params: GeminiGenerateParams): Promise<string[]> {
-  if (process.env.MOCK_GEMINI === 'true' || !GEMINI_API_URL || !GEMINI_API_KEY) {
+  console.log('🤖 [GEMINI_SERVICE] ===== GEMINI API CALL STARTED =====');
+  console.log('🤖 [GEMINI_SERVICE] 🔧 Environment check:');
+  console.log('🤖 [GEMINI_SERVICE] 🔧 - MOCK_GEMINI:', process.env.MOCK_GEMINI);
+  console.log('🤖 [GEMINI_SERVICE] 🔧 - GEMINI_API_KEY:', GEMINI_API_KEY ? 'SET' : 'MISSING');
+  console.log('🤖 [GEMINI_SERVICE] 🔧 - GEMINI_IMAGE_MODEL:', GEMINI_IMAGE_MODEL);
+  
+  console.log('🤖 [GEMINI_SERVICE] 📝 Input parameters:');
+  console.log('🤖 [GEMINI_SERVICE] 📝 - Prompt length:', params.prompt?.length || 0);
+  console.log('🤖 [GEMINI_SERVICE] 📝 - Human image URL:', params.humanImageUrl?.substring(0, 100) + '...');
+  console.log('🤖 [GEMINI_SERVICE] 📝 - Garment image URL:', params.garmentImageUrl?.substring(0, 100) + '...' || 'N/A');
+  
+  console.log('🤖 [GEMINI_SERVICE] ===== COMPLETE PROMPT =====');
+  console.log('🤖 [GEMINI_SERVICE] 📄 PROMPT:', params.prompt);
+  console.log('🤖 [GEMINI_SERVICE] ===== END PROMPT =====');
+
+  if (process.env.MOCK_GEMINI === 'true' || !GEMINI_API_KEY) {
+    console.log('🤖 [GEMINI_SERVICE] 🎭 Using MOCK mode - returning placeholder image');
     // Minimal mock data URI to avoid network
     return [
       "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChAI9jU77hQAAAABJRU5ErkJggg=="
     ];
   }
 
-  // Prepare optional garment image as base64 if provided
+  // Prepare images as base64 inline_data
+  console.log('🤖 [GEMINI_SERVICE] 🔄 Converting images to base64...');
+  const humanImageBase64 = await urlToFile(params.humanImageUrl, params.humanImageName, params.humanImageType).then(fileToBase64);
+  console.log('🤖 [GEMINI_SERVICE] 🔄 Human image converted, size:', humanImageBase64.length, 'chars');
+  
   let garmentImageBase64: string | undefined = undefined;
   if (params.garmentImageUrl && params.garmentImageName && params.garmentImageType) {
     garmentImageBase64 = await urlToFile(params.garmentImageUrl, params.garmentImageName, params.garmentImageType).then(fileToBase64);
+    console.log('🤖 [GEMINI_SERVICE] 🔄 Garment image converted, size:', garmentImageBase64?.length || 0, 'chars');
   }
 
-  const body: Record<string, unknown> = {
-    prompt: params.prompt,
-    human_image_url: params.humanImageUrl,
-  };
+  const endpoint = `https://generativelanguage.googleapis.com/v1beta/models/${GEMINI_IMAGE_MODEL}:generateContent?key=${GEMINI_API_KEY}`;
+  console.log('🤖 [GEMINI_SERVICE] 🌐 API Endpoint:', endpoint.replace(GEMINI_API_KEY, '[REDACTED_KEY]'));
+
+  const parts: any[] = [
+    { text: params.prompt },
+    { inline_data: { mime_type: params.humanImageType, data: humanImageBase64 } },
+  ];
   if (garmentImageBase64) {
-    body["garment_image_base64"] = garmentImageBase64;
+    parts.push({ inline_data: { mime_type: params.garmentImageType, data: garmentImageBase64 } });
   }
 
-  const resp = await fetchWithTimeout(GEMINI_API_URL, {
+  const body = {
+    contents: [ { parts } ],
+    generationConfig: { responseModalities: ["IMAGE"] }
+  };
+  
+  console.log('🤖 [GEMINI_SERVICE] 📦 Request body structure:');
+  console.log('🤖 [GEMINI_SERVICE] 📦 - Contents count:', body.contents.length);
+  console.log('🤖 [GEMINI_SERVICE] 📦 - Parts count:', parts.length);
+  console.log('🤖 [GEMINI_SERVICE] 📦 - Response modalities:', body.generationConfig.responseModalities);
+  console.log('🤖 [GEMINI_SERVICE] 📦 - Parts types:', parts.map(p => Object.keys(p)).join(', '));
+
+  console.log('🤖 [GEMINI_SERVICE] 🚀 Sending request to Gemini API...');
+  const resp = await fetchWithTimeout(endpoint, {
     method: 'POST',
-    headers: {
-      'Authorization': `Bearer ${GEMINI_API_KEY}`,
-      'Content-Type': 'application/json',
-    },
+    headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(body),
-    timeout: 120000,
+    timeout: 180000,
   });
+
+  console.log('🤖 [GEMINI_SERVICE] 📡 Response received:');
+  console.log('🤖 [GEMINI_SERVICE] 📡 - Status:', resp.status);
+  console.log('🤖 [GEMINI_SERVICE] 📡 - Status text:', resp.statusText);
+  console.log('🤖 [GEMINI_SERVICE] 📡 - OK:', resp.ok);
 
   if (!resp.ok) {
     const text = await resp.text();
+    console.log('🤖 [GEMINI_SERVICE] ❌ Error response body:', text);
     throw new Error(`Gemini API error: ${resp.status} ${text}`);
   }
 
   const data = await resp.json();
-  // Expecting { images: [{ url: string }, ...] } or { url: string }
-  let urls: string[] = [];
-  if (Array.isArray(data?.images)) {
-    urls = data.images.map((x: any) => x.url).filter(Boolean);
-  } else if (data?.url) {
-    urls = [data.url];
+  console.log('🤖 [GEMINI_SERVICE] 📥 Success response received');
+  console.log('🤖 [GEMINI_SERVICE] 📥 Response keys:', Object.keys(data));
+  // Extract inline image data from candidates[0].content.parts[*].inlineData/inline_data
+  console.log('🤖 [GEMINI_SERVICE] 🔍 Parsing response for images...');
+  const candidates = data?.candidates || [];
+  console.log('🤖 [GEMINI_SERVICE] 🔍 Candidates count:', candidates.length);
+  
+  const images: string[] = [];
+  for (const c of candidates) {
+    const parts = c?.content?.parts || [];
+    console.log('🤖 [GEMINI_SERVICE] 🔍 Parts in candidate:', parts.length);
+    
+    for (const p of parts) {
+      const inline = p.inlineData || p.inline_data;
+      if (inline?.data) {
+        const mime = inline.mimeType || inline.mime_type || 'image/png';
+        images.push(`data:${mime};base64,${inline.data}`);
+        console.log('🤖 [GEMINI_SERVICE] 🔍 Found image, mime type:', mime);
+        console.log('🤖 [GEMINI_SERVICE] 🔍 Image data length:', inline.data.length, 'chars');
+      }
+    }
   }
-  if (!urls.length) {
-    throw new Error("Gemini API returned no images");
+  
+  console.log('🤖 [GEMINI_SERVICE] ✅ Total images extracted:', images.length);
+  
+  if (!images.length) {
+    console.log('🤖 [GEMINI_SERVICE] ❌ No images found in response');
+    console.log('🤖 [GEMINI_SERVICE] ❌ Full response data:', JSON.stringify(data, null, 2));
+    throw new Error("Gemini API returned no inline images");
   }
-  return urls;
+  
+  console.log('🤖 [GEMINI_SERVICE] ===== GEMINI API CALL COMPLETED =====');
+  return images;
 }
 
 

--- a/lib/ai/types.ts
+++ b/lib/ai/types.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import zodToJsonSchema from "zod-to-json-schema";
 import { type OnboardingData } from "@/lib/onboarding-storage";
+import { ProviderId } from "./providers/types";
 
 // Zod schema for structured output, matching the format in lib/prompts.ts
 export const itemDetailSchema = z.object({
@@ -96,6 +97,7 @@ export interface Job {
     generationMode: GenerationMode;
     occasion: string;
     userProfile?: any;
+    provider?: ProviderId;
     customPrompt?: string;
     stylePrompt?: string; // 🔍 新增：场景风格提示
   };


### PR DESCRIPTION
…ider on job; guard status to avoid Kling auto-start; make /api/generation/new return JSON (no SSE)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces SSE with a JSON-based generation flow using FormData uploads, integrates Gemini image generation, and persists the selected provider to gate pipeline auto-start (Kling-only).
> 
> - **Backend**:
>   - **/api/generation/new**: Replace SSE with direct provider execution and JSON response; persist `input.provider`; select provider via `generation_provider` or env; add progress logging; keep job limit, save, and cleanup steps.
>   - **/api/generation/status**: Use persisted `input.provider` to only auto-start pipeline when `provider === 'kling'`.
> - **Frontend**:
>   - `app/chat1/useGeneration.ts`: Upload images via `FormData` and call `/api/generation/new`; include `generation_provider="gemini"`; update polling setup.
> - **AI Providers/Services**:
>   - `GeminiProvider`: Add detailed logging; include image metadata; save results to `kv`.
>   - `lib/ai/services/gemini.ts`: Rework to call Google Generative Language API with inline base64 image parts; parse candidates for inline images; add extensive diagnostics and mock fallback.
> - **Types**:
>   - `lib/ai/types.ts`: Add optional `input.provider: ProviderId`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7e5e627f8bb18e3a88aca5c42815845ac0f5414b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->